### PR TITLE
Add webhook support as alternative to Home Assistant API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,46 @@ Or you can download and build it yourself:
 
 ## Configuration
 
+The extension now supports two methods for updating Home Assistant entities:
+
+### Method 1: API (Default)
 1. [Generate a long-lived access token in Home Assistant](https://www.atomicha.com/home-assistant-how-to-generate-long-lived-access-token-part-1/)
 2. [Create a new input boolean in Home Assistant](https://www.home-assistant.io/integrations/input_boolean/). If you use Google Meet on multiple computers or Chrome profiles, create separate input boolean for each one.
 3. Click on the Chrome extension in your browser to open the configuration page and configure your Home Assistant URL, auth token, and input boolean entity ID accordingly.
+
+### Method 2: Webhook
+1. [Create a webhook automation in Home Assistant](https://www.home-assistant.io/docs/automation/trigger/#webhook-trigger) that receives JSON data with a `value` field
+2. Configure the webhook to update your desired entity based on the received value (`"on"` or `"off"`)
+3. Click on the Chrome extension in your browser, select "Webhook" as the update method, and enter your webhook URL
+
+**Example webhook automation in Home Assistant:**
+```yaml
+automation:
+  - alias: "Google Meet Status Webhook"
+    trigger:
+      platform: webhook
+      webhook_id: "google_meet_status"
+    variables:
+      meeting_status: "{{ trigger.json.value }}"
+    action:
+      choose:
+        - conditions:
+            - condition: template
+              value_template: "{{ meeting_status == 'on' }}"
+          sequence:
+            - service: input_boolean.turn_on
+              target:
+                entity_id: input_boolean.in_meeting
+        - conditions:
+            - condition: template
+              value_template: "{{ meeting_status == 'off' }}"
+          sequence:
+            - service: input_boolean.turn_off
+              target:
+                entity_id: input_boolean.in_meeting
+```
+
+The webhook URL would be: `https://your-ha-domain.com/api/webhook/google_meet_status`
 
 ![](screenshot.png)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,19 @@
+export type UpdateMethod = "api" | "webhook";
+
 export interface Config {
     host: string;
     token: string;
     entity_id: string;
+    method: UpdateMethod;
+    webhook_url: string;
 }
 
 export const defaultConfig: Config = {
     host: "http://homeassistant.local",
     token: "xxxxxxx",
     entity_id: "input_boolean.in_meeting",
+    method: "api",
+    webhook_url: "",
 };
 
 export async function loadConfig(): Promise<Config> {

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom";
-import { Config, defaultConfig, loadConfig, saveConfig } from "./config";
+import { Config, defaultConfig, loadConfig, saveConfig, UpdateMethod } from "./config";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
 import LoadingButton from "@mui/lab/LoadingButton";
@@ -9,8 +9,13 @@ import {
     Box,
     Button,
     Divider,
+    FormControl,
+    FormControlLabel,
+    FormLabel,
     IconButton,
     InputAdornment,
+    Radio,
+    RadioGroup,
     Snackbar,
     Stack,
     TextField,
@@ -75,68 +80,107 @@ const Options = () => {
                     }}
                 >
                     <Box>
-                        <TextField
-                            id="host"
-                            name="host"
-                            label="Home Assistant Base URL"
-                            value={config.host}
-                            onChange={(e) =>
-                                setConfig({ ...config, host: e.target.value })
-                            }
-                            helperText="No trailing slashes; ex: http://homeassistant.local"
-                            variant="standard"
-                            fullWidth
-                        />
+                        <FormControl component="fieldset">
+                            <FormLabel component="legend">Update Method</FormLabel>
+                            <RadioGroup
+                                value={config.method}
+                                onChange={(e) =>
+                                    setConfig({ ...config, method: e.target.value as UpdateMethod })
+                                }
+                            >
+                                <FormControlLabel value="api" control={<Radio />} label="API" />
+                                <FormControlLabel value="webhook" control={<Radio />} label="Webhook" />
+                            </RadioGroup>
+                        </FormControl>
                     </Box>
-                    <Box>
-                        <TextField
-                            id="token"
-                            name="token"
-                            type={showToken ? "text" : "password"}
-                            label="Authorization Token"
-                            value={config.token}
-                            onChange={(e) =>
-                                setConfig({ ...config, token: e.target.value })
-                            }
-                            variant="standard"
-                            fullWidth
-                            InputProps={{
-                                endAdornment: (
-                                    <InputAdornment position="end">
-                                        <IconButton
-                                            aria-label="Toggle auth token visibility"
-                                            onClick={() =>
-                                                setShowToken(!showToken)
-                                            }
-                                            edge="end"
-                                        >
-                                            {showToken ? (
-                                                <Visibility />
-                                            ) : (
-                                                <VisibilityOff />
-                                            )}
-                                        </IconButton>
-                                    </InputAdornment>
-                                ),
-                            }}
-                        />
-                    </Box>
-                    <Box>
-                        <TextField
-                            id="entity_id"
-                            name="entity_id"
-                            label="Entity ID"
-                            value={config.entity_id}
-                            onChange={(e) =>
-                                setConfig({
-                                    ...config,
-                                    entity_id: e.target.value,
-                                })
-                            }
-                            variant="standard"
-                            fullWidth
-                        />
-                    </Box>
+                    {config.method === "api" && (
+                        <Box>
+                            <TextField
+                                id="host"
+                                name="host"
+                                label="Home Assistant Base URL"
+                                value={config.host}
+                                onChange={(e) =>
+                                    setConfig({ ...config, host: e.target.value })
+                                }
+                                helperText="No trailing slashes; ex: http://homeassistant.local"
+                                variant="standard"
+                                fullWidth
+                            />
+                        </Box>
+                    )}
+                    {config.method === "webhook" && (
+                        <Box>
+                            <TextField
+                                id="webhook_url"
+                                name="webhook_url"
+                                label="Webhook URL"
+                                value={config.webhook_url}
+                                onChange={(e) =>
+                                    setConfig({ ...config, webhook_url: e.target.value })
+                                }
+                                helperText="Full webhook URL including entity ID; ex: https://ha.example.com/api/webhook/entity_webhook"
+                                variant="standard"
+                                fullWidth
+                                required
+                            />
+                        </Box>
+                    )}
+                    {config.method === "api" && (
+                        <Box>
+                            <TextField
+                                id="token"
+                                name="token"
+                                type={showToken ? "text" : "password"}
+                                label="Authorization Token"
+                                value={config.token}
+                                onChange={(e) =>
+                                    setConfig({ ...config, token: e.target.value })
+                                }
+                                variant="standard"
+                                fullWidth
+                                required
+                                InputProps={{
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <IconButton
+                                                aria-label="Toggle auth token visibility"
+                                                onClick={() =>
+                                                    setShowToken(!showToken)
+                                                }
+                                                edge="end"
+                                            >
+                                                {showToken ? (
+                                                    <Visibility />
+                                                ) : (
+                                                    <VisibilityOff />
+                                                )}
+                                            </IconButton>
+                                        </InputAdornment>
+                                    ),
+                                }}
+                            />
+                        </Box>
+                    )}
+                    {config.method === "api" && (
+                        <Box>
+                            <TextField
+                                id="entity_id"
+                                name="entity_id"
+                                label="Entity ID"
+                                value={config.entity_id}
+                                onChange={(e) =>
+                                    setConfig({
+                                        ...config,
+                                        entity_id: e.target.value,
+                                    })
+                                }
+                                variant="standard"
+                                fullWidth
+                                required
+                            />
+                        </Box>
+                    )}
                     <Stack direction="row" spacing={2}>
                         <LoadingButton
                             size="small"


### PR DESCRIPTION
I didn't feel that access to the API was necessary and secure, so I implemented a webhook-based solution that doesn't create such wide exposure, and allows for strictly restricting operations performed.

## Summary

- Add webhook update method option in settings UI with radio button selection for choosing between API and webhook methods
- Implement webhook POST requests with `{"value":"on/off"}` payload format that doesn't require authentication
- Add webhook testing functionality that validates HTTP 200 response to ensure webhook endpoint is working correctly

## Changes Made
- Extended `Config` interface to include `method` and `webhook_url` fields with backward compatibility
- Updated settings UI with conditional field display based on selected method (API vs webhook)
- Implemented separate functions for API and webhook entity state updates in `hass.ts`
- Added comprehensive webhook testing that sends test payload and validates response
- Updated README with webhook configuration instructions and Home Assistant automation example

## Test plan
- [x] Verify API method still works for existing configurations (backward compatibility)  
- [x] Test webhook method with valid webhook URL returns success
- [x] Test webhook method with invalid URL shows appropriate error message
- [x] Verify UI correctly shows/hides fields based on selected method
- [x] Confirm both methods work in background script for actual meeting detection
- [x] Manual testing with actual Home Assistant webhook automation

🤖 Generated with [Claude Code](https://claude.ai/code)